### PR TITLE
Added some properties to help determine the state of the menu.

### DIFF
--- a/src/RadialMenu/RadialMenu/ALRadialMenu.cs
+++ b/src/RadialMenu/RadialMenu/ALRadialMenu.cs
@@ -101,9 +101,13 @@ namespace DK.Ostebaronen.Touch.RadialMenu
             _dismissGesture?.Dispose();
             _dismissGesture = null;
 
-            _overlayView?.RemoveFromSuperview();
-            _overlayView?.Dispose();
-            _overlayView = null;
+            if (_overlayView != null)
+            {
+                _overlayView.OnPointInside -= OnPointInside;
+                _overlayView.RemoveFromSuperview();
+                _overlayView.Dispose();
+                _overlayView = null;
+            }
 
             _dismissGesture = new UITapGestureRecognizer(InternalDismiss)
             {
@@ -116,7 +120,13 @@ namespace DK.Ostebaronen.Touch.RadialMenu
                 PassThroughTouchEvents = !_overlayCancelsTouchesInView
             };
             _overlayView.AddGestureRecognizer(_dismissGesture);
-            _overlayView.OnOverlayPointInside += OverlayView_OnOverlayPointInside;
+            _overlayView.OnPointInside += OnPointInside;
+        }
+
+        private void OnPointInside(object sender, EventArgs e)
+        {
+            if (_dismissOnOverlayTap)
+                InternalDismiss();
         }
 
         /// <summary>
@@ -379,12 +389,6 @@ namespace DK.Ostebaronen.Touch.RadialMenu
                 });
         }
 
-        private void OverlayView_OnOverlayPointInside(CGPoint point, UIEvent uievent)
-        {
-            if (_dismissOnOverlayTap)
-                InternalDismiss();
-        }
-
         private static CGPoint PointOnCircumference(CGPoint origin, float radius, Angle angle)
         {
             var radians = angle.Radians;
@@ -413,6 +417,7 @@ namespace DK.Ostebaronen.Touch.RadialMenu
 
                 if (_overlayView != null)
                 {
+                    _overlayView.OnPointInside -= OnPointInside;
                     _overlayView.RemoveFromSuperview();
                     _overlayView.RemoveGestureRecognizer(_dismissGesture);
                     _overlayView.Dispose();

--- a/src/RadialMenu/RadialMenu/ALRadialMenu.cs
+++ b/src/RadialMenu/RadialMenu/ALRadialMenu.cs
@@ -12,6 +12,16 @@ namespace DK.Ostebaronen.Touch.RadialMenu
     [Preserve(AllMembers = true)]
     public class ALRadialMenu : UIButton
     {
+        /// <summary>
+        /// This event is invoked whenever the menu is dismissed.
+        /// </summary>
+        public event EventHandler OnDismissing;
+
+        /// <summary>
+        /// This event is invoked when the menu is starting its animation.
+        /// </summary>
+        public event EventHandler OnShowing;
+
         private UITapGestureRecognizer _dismissGesture;
         private bool _dismissOnOverlayTap = true;
         private bool _overlayCancelsTouchesInView = true;
@@ -73,15 +83,12 @@ namespace DK.Ostebaronen.Touch.RadialMenu
         public Action<UIView> SelectedButtonAnimation { get; set; }
 
         /// <summary>
-        /// This event is invoked whenever the menue is dismissed.
+        /// Get wheter the menu is currently showing.
+        /// 
+        /// This will be false when animation of the last button has finished.
+        /// This will be true when the animation of the first button has started.
         /// </summary>
-        public event EventHandler OnDismissing;
-
-        /// <summary>
-        /// This property is an indicator to wether the radial menu is currently unfolded or not.
-        /// The property will only display false when the animation of the last button has finished and true once the animation of the first button starts.
-        /// </summary>
-        public bool IsUnfolded { get; private set; }
+        public bool IsShowing { get; private set; }
 
         public ALRadialMenu() : this(CGRect.Empty) { }
 
@@ -267,10 +274,12 @@ namespace DK.Ostebaronen.Touch.RadialMenu
                 return this;
             }
 
-            if (IsUnfolded)
+            if (IsShowing)
                 return this;
 
-            IsUnfolded = true;
+            OnShowing?.Invoke(this, EventArgs.Empty);
+            IsShowing = true;
+
             if (_animationOrigin.IsEmpty)
                 _animationOrigin = Center;
 
@@ -295,13 +304,10 @@ namespace DK.Ostebaronen.Touch.RadialMenu
         {
             if (Buttons == null || Buttons.Count == 0)
             {
-                IsUnfolded = false;
+                IsShowing = false;
                 Debug.WriteLine("ALRadialMenu has no buttons to present");
                 return this;
             }
-
-            if (IsUnfolded)
-                OnDismissing?.Invoke(this, null);
 
             Dismiss(-1);
 
@@ -312,6 +318,9 @@ namespace DK.Ostebaronen.Touch.RadialMenu
 
         private void Dismiss(int selectedIndex)
         {
+            if (IsShowing)
+                OnDismissing?.Invoke(this, null);
+
             _overlayView.RemoveFromSuperview();
 
             for (var i = 0; i < Buttons.Count; i++)
@@ -365,7 +374,7 @@ namespace DK.Ostebaronen.Touch.RadialMenu
                 {
                     view.RemoveFromSuperview();
                     if (index == Buttons.Count - 1)
-                        IsUnfolded = false;
+                        IsShowing = false;
                 });
         }
 

--- a/src/RadialMenu/RadialMenu/ALRadialMenu.cs
+++ b/src/RadialMenu/RadialMenu/ALRadialMenu.cs
@@ -257,6 +257,9 @@ namespace DK.Ostebaronen.Touch.RadialMenu
                 return this;
             }
 
+            if (IsUnfolded)
+                return this;
+
             IsUnfolded = true;
             if (_animationOrigin.IsEmpty)
                 _animationOrigin = Center;

--- a/src/RadialMenu/RadialMenu/PassThroughView.cs
+++ b/src/RadialMenu/RadialMenu/PassThroughView.cs
@@ -6,6 +6,9 @@ namespace DK.Ostebaronen.Touch.RadialMenu
 {
     internal class PassThroughView : UIView
     {
+        public delegate void PointInsideDelegate(CGPoint point, UIEvent uievent);
+
+        public event PointInsideDelegate OnOverlayPointInside;
         public PassThroughView() { }
         public PassThroughView(CGRect frame) : base(frame) { }
 
@@ -13,6 +16,8 @@ namespace DK.Ostebaronen.Touch.RadialMenu
 
         public override bool PointInside(CGPoint point, UIEvent uievent)
         {
+            OnOverlayPointInside?.Invoke(point, uievent);
+
             if (PassThroughTouchEvents)
                 return Subviews.Any(s => !s.Hidden && s.PointInside(point, uievent));
 

--- a/src/RadialMenu/RadialMenu/PassThroughView.cs
+++ b/src/RadialMenu/RadialMenu/PassThroughView.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using CoreGraphics;
 using UIKit;
 
@@ -6,9 +7,7 @@ namespace DK.Ostebaronen.Touch.RadialMenu
 {
     internal class PassThroughView : UIView
     {
-        public delegate void PointInsideDelegate(CGPoint point, UIEvent uievent);
-
-        public event PointInsideDelegate OnOverlayPointInside;
+        public event EventHandler OnPointInside;
         public PassThroughView() { }
         public PassThroughView(CGRect frame) : base(frame) { }
 
@@ -16,7 +15,7 @@ namespace DK.Ostebaronen.Touch.RadialMenu
 
         public override bool PointInside(CGPoint point, UIEvent uievent)
         {
-            OnOverlayPointInside?.Invoke(point, uievent);
+            OnPointInside?.Invoke(this, EventArgs.Empty);
 
             if (PassThroughTouchEvents)
                 return Subviews.Any(s => !s.Hidden && s.PointInside(point, uievent));


### PR DESCRIPTION
Added a property to help determine whether the menu is opened or closed.
Added an event which is invoked when the menu is closing.
The menu is now prevented from unfolding if it is already unfolded. This fixed a UI bug where some of the buttons could get into an undesirable state if the menu was presented and dismissed before the animations had finished.